### PR TITLE
Added query string parameter to allow for synchronous install.  

### DIFF
--- a/SitecorePackageDeployer.Web/sitecore/admin/StartSitecorePackageDeployer.aspx.cs
+++ b/SitecorePackageDeployer.Web/sitecore/admin/StartSitecorePackageDeployer.aspx.cs
@@ -1,11 +1,6 @@
 ﻿using Hhogdev.SitecorePackageDeployer.Tasks;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
-using System.Web;
-using System.Web.UI;
-using System.Web.UI.WebControls;
 
 namespace Hhogdev.SitecorePackageDeployer.Web.sitecore.admin
 {
@@ -18,11 +13,20 @@ namespace Hhogdev.SitecorePackageDeployer.Web.sitecore.admin
                 InstallPackage.ResetInstallState();
             }
 
-            ThreadPool.QueueUserWorkItem((ctx) =>
+            if (Request.QueryString["synchronous"] == "1")
             {
-                InstallPackage installer = new InstallPackage();
+                var installer = new InstallPackage();
                 installer.Run();
-            });
+            }
+            else
+            {
+                ThreadPool.QueueUserWorkItem((ctx) =>
+                {
+                    var installer = new InstallPackage();
+                    installer.Run();
+                });
+            }
+                
         }
     }
 }


### PR DESCRIPTION
This is useful in a CM/CD scenario where first, the CM server is built, and then upon success, the CD server is built and a subsequen publish is executed. Without this, the deployment to CM happens nearly instantly, which tells the build server the release is complete, and then triggers a CD deployment.  Subsequently, the CD server completes it's release all the while the install is still occurring on CM.

We are manually calling StartSitecorePackageDeployer.aspx and so the request completes as soon as the website is recompiled, giving a false positive.

Adding this simple change ensures the request doesn't return until the package is installed and all Post Deploy actions have completed.